### PR TITLE
Avoid a font whose 'I' looks like an 'l'

### DIFF
--- a/HTML/assets/index.css
+++ b/HTML/assets/index.css
@@ -1,12 +1,3 @@
-/* http://www.google.com/fonts#UsePlace:use/Collection:Source+Sans+Pro */
-@font-face {
-    font-family: 'Source Sans Pro';
-    font-style: normal;
-    font-weight: 400;
-    src: local('Source Sans Pro'), local('SourceSansPro-Regular'),
-         url(source_sans_pro-latin_ext.woff) format('woff');
-}
-
 .logo {
     min-height: 16px;
     max-height: 64px;
@@ -37,5 +28,5 @@ only screen and (-webkit-min-device-pixel-ratio: 2) {
 
 /* Use IDs over 'input' selector to override jQuery Mobile theming. */
 #nickname, #masterPassword, #validateMasterPassword, #accountPassword {
-    font-family: 'Source Sans Pro', monospace;
+    font-family: monospace;
 }


### PR DESCRIPTION
Either serif or monospace is better than sans-serif when you want to keep the letterforms distinct.
